### PR TITLE
fix for bidirectional reactions

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -7,24 +7,24 @@
 
 ## Modify a model
 
-We list common transition attributes:
+We list common transition attributes. When being specified using the `@ReactionNetwork` macro they can be conveniently referred to using their shorthand description.
 
-| attribute | interpretation |
-| :----- | :----- |
-| `transPriority` | priority of a transition (influences resource allocation) |
-| `transProbOfSuccess` | probability that a transition terminates successfully |
-| `transCapacity` | maximum number of concurrent instances of the transition |
-| `transCycleTime` | duration of a transition's instance (adjusted by resource allocation) |
-| `transMaxLifeTime` | maximal duration of a transition's instance |
-| `transPostAction` | action to be executed once a transition's instance terminates |
-| `transName` | name of a transition |
+| attribute | shorthand | interpretation |
+| :----- | :----- | :----- |
+| `transPriority` | `priority` | priority of a transition (influences resource allocation) |
+| `transProbOfSuccess` | `probability` `prob` `pos` | probability that a transition terminates successfully |
+| `transCapacity` | `cap` `capacity` | maximum number of concurrent instances of the transition |
+| `transCycleTime` | `ct` `cycletime` | duration of a transition's instance (adjusted by resource allocation) |
+| `transMaxLifeTime` | `lifetime` `maxlifetime` `maxtime` `timetolive` | maximal duration of a transition's instance |
+| `transPostAction` | `postAction` `post` | action to be executed once a transition's instance terminates |
+| `transName` | `name` `interpretation` | name of a transition, either a string or unquoted text |
 
 We list common species attributes:
 
-| attribute | interpretation |
-| :----- | :----- |
-| `specInitUncertainty` | uncertainty about variable's initial state (modelled as Gaussian standard deviation) |
-| `specInitVal` | initial value of a variable |
+| attribute | shorthand | interpretation |
+| :----- | :----- | :----- |
+| `specInitUncertainty` | `uncertainty` `stoch` `stochasticity` | uncertainty about variable's initial state (modelled as Gaussian standard deviation) |
+| `specInitVal` | | initial value of a variable |
 
 Moreover, it is possible to specify the semantics of the "rate" term. By default, at each time step `n ~ Poisson(rate * dt)` instances of a given transition will be spawned. If you want to specify the rate in terms of a cycle time, you may want to use `@ct(cycle_time)`, e.g., `@ct(ex), A --> B, ...`. This is a shorthand for `1/ex, A --> B, ...`.
 

--- a/src/interface/create.jl
+++ b/src/interface/create.jl
@@ -173,7 +173,8 @@ function get_transitions!(trans, reactants, pcs, exs)
     (rate, r_line) = exs[1:2]
     rxs = prune_reaction_line!(pcs, reactants, r_line)
     rate = expand_rate(rate)
-    rxs = rxs isa Tuple ? tuple.(rate.args, rxs) : ((rate, rxs),)
+    # rxs = rxs isa Tuple ? tuple.(rate.args, rxs) : ((rate, rxs),)
+    rxs = rxs isa Tuple ? tuple.(fill(rate, length(rxs)), rxs) : ((rate, rxs),)
 
     exs = exs[3:end]
     empty!(args)

--- a/src/interface/create.jl
+++ b/src/interface/create.jl
@@ -173,7 +173,6 @@ function get_transitions!(trans, reactants, pcs, exs)
     (rate, r_line) = exs[1:2]
     rxs = prune_reaction_line!(pcs, reactants, r_line)
     rate = expand_rate(rate)
-    # rxs = rxs isa Tuple ? tuple.(rate.args, rxs) : ((rate, rxs),)
     rxs = rxs isa Tuple ? tuple.(fill(rate, length(rxs)), rxs) : ((rate, rxs),)
 
     exs = exs[3:end]

--- a/tutorial/basics.jl
+++ b/tutorial/basics.jl
@@ -4,9 +4,7 @@ using ReactiveDynamics
 #     1.0, X ⟺ Y
 # end
 
-acs = @ReactionNetwork begin
-    1.0, X ⟺ Y, name=>"transition1"
-end
+acs = @ReactionNetwork begin 1.0, X ⟺ Y, name => "transition1" end
 
 @prob_init acs X=10 Y=20
 @prob_params acs

--- a/tutorial/basics.jl
+++ b/tutorial/basics.jl
@@ -1,0 +1,9 @@
+using ReactiveDynamics
+
+acs = @ReactionNetwork begin
+    1.0, X ⟺ Y
+end
+
+acs = @ReactionNetwork begin
+    1.0, X ⟺ Y, name=>"transition1"
+end

--- a/tutorial/basics.jl
+++ b/tutorial/basics.jl
@@ -1,8 +1,8 @@
 using ReactiveDynamics
 
-acs = @ReactionNetwork begin
-    1.0, X ⟺ Y
-end
+# acs = @ReactionNetwork begin
+#     1.0, X ⟺ Y
+# end
 
 acs = @ReactionNetwork begin
     1.0, X ⟺ Y, name=>"transition1"
@@ -14,6 +14,10 @@ end
 
 prob = @problematize acs
 
-# sol = @solve prob trajectories=50
+# sol = ReactiveDynamics.solve(prob)
 
-ReactiveDynamics.solve(prob)
+sol = @solve prob trajectories=20
+
+using Plots
+
+@plot sol plot_type=summary

--- a/tutorial/basics.jl
+++ b/tutorial/basics.jl
@@ -7,3 +7,13 @@ end
 acs = @ReactionNetwork begin
     1.0, X ⟺ Y, name=>"transition1"
 end
+
+@prob_init acs X=10 Y=20
+@prob_params acs
+@prob_meta acs tspan=250 dt=0.1
+
+prob = @problematize acs
+
+# sol = @solve prob trajectories=50
+
+ReactiveDynamics.solve(prob)


### PR DESCRIPTION
Hi @thevolatilebit, I believe this change in `get_transitions!` should address #9, but I don't yet fully understand the software design. Previously the generated expression to sample the number of firings per time step would only be made for one of the two reactions coming from the bidirectional transition but now it makes it for both, and the system in tutorial/basics.jl works correctly. 